### PR TITLE
fix load_models, models.reject! returns nil and not the modified array

### DIFF
--- a/lib/i18n_model_translator/models/model_translation.rb
+++ b/lib/i18n_model_translator/models/model_translation.rb
@@ -57,6 +57,7 @@ module I18nTranslator
           models = ActiveRecord::Base.descendants
           models.delete([ActiveRecord::SchemaMigration])
           models.reject! { |model| model.name.include?('HABTM') | !model.table_exists? }
+          return models
         end
 
         def write_to_file(model, locale, content)

--- a/lib/tasks/i18n_model_translator.rake
+++ b/lib/tasks/i18n_model_translator.rake
@@ -4,12 +4,14 @@ namespace :i18n_model_translator do
 
   desc 'prints out the locale for one specific model'
   task :print_model, [:model] => :environment do |t, args|
-    puts I18nTranslator::Models::ModelTranslation.generate_model_translation(args[:model].constantize, :en)
+    model = args[:model].classify.constantize
+    puts I18nTranslator::Models::ModelTranslation.generate_model_translation(model, :en)
   end
 
   desc 'prints out the model locale for the given model into /config/locales/models/model_name/en.yml'
   task :print_model_to_file, [:model] => :environment do |t, args|
-    I18nTranslator::Models::ModelTranslation.write_model_translation(args[:model].constantize, :en)
+    model = args[:model].classify.constantize
+    I18nTranslator::Models::ModelTranslation.write_model_translation(model, :en)
   end
 
   desc 'prints out the locales for each model in the environment'


### PR DESCRIPTION
```
 $ rake i18n_model_translator:print_all_models --trace                                                                                                                                                                                       [11:15:01]
** Invoke i18n_model_translator:print_all_models (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute i18n_model_translator:print_all_models
rake aborted!
NoMethodError: undefined method `each' for nil:NilClass
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/i18n_model_translator-1.0.0/lib/i18n_model_translator/models/model_translation.rb:23:in `print_all_model_translations'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/i18n_model_translator-1.0.0/lib/tasks/i18n_model_translator.rake:17:in `block (2 levels) in <top (required)>'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/Users/endorfin/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/Users/endorfin/.rbenv/versions/2.0.0-p598/bin/rake:23:in `load'
/Users/endorfin/.rbenv/versions/2.0.0-p598/bin/rake:23:in `<main>'
Tasks: TOP => i18n_model_translator:print_all_models
```
